### PR TITLE
Adds new session option to ignore response cookies

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -128,9 +128,11 @@ export class Session {
         }
 
         const responseCookieJar = new CookieJar();
-        if (responseObject.headers['Set-Cookie'] && Array.isArray(responseObject.headers['Set-Cookie'])) {
-            for (const cookie of responseObject.headers['Set-Cookie']) {
-                await responseCookieJar.setCookie(cookie, url);
+        if (!(this.sessionOptions.ignoreResponseCookies ?? false)) {
+            if (responseObject.headers['Set-Cookie'] && Array.isArray(responseObject.headers['Set-Cookie'])) {
+                for (const cookie of responseObject.headers['Set-Cookie']) {
+                    await responseCookieJar.setCookie(cookie, url);
+                }
             }
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface SessionConstructorOptions {
     headerPriority?: Record<string, number>;
     randomTlsExtensionOrder?: boolean;
     forceHttp1?: boolean;
+    ignoreResponseCookies?: boolean;
 }
 
 export interface RequestPayload {


### PR DESCRIPTION
I was using lib to fetch data from a site that for some unknown reason sends back invalid "Set-Cookie" header, causing error in "touch-cookie" parser. Found no way to skip reading the response cookies, so added a simple flag in session options. Maybe would be nicer to add some way to add custom middlewares to transform request/response? Feel free to reject and add better solution :)